### PR TITLE
Cell edges that cross boundaries now form complete loops

### DIFF
--- a/Voronoi.xcodeproj/project.pbxproj
+++ b/Voronoi.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		DC11AF741CFFCC72001439BA /* VoronoiSiteEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC11AF731CFFCC72001439BA /* VoronoiSiteEvent.swift */; };
 		DC11AF7A1CFFCC7C001439BA /* VoronoiCircleEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC11AF791CFFCC7C001439BA /* VoronoiCircleEvent.swift */; };
 		DC11AF801CFFCF97001439BA /* Circle.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC11AF7F1CFFCF97001439BA /* Circle.swift */; };
+		DC2332221D204AC90013C3A9 /* VoronoiDiagramEdgeValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2332211D204AC90013C3A9 /* VoronoiDiagramEdgeValidator.swift */; };
 		DC8F110C1D0CB33800353DFB /* VoronoiLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8F110B1D0CB33800353DFB /* VoronoiLine.swift */; };
 		DC8F11191D0CD19B00353DFB /* GLSVoronoiSprite.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8F11181D0CD19B00353DFB /* GLSVoronoiSprite.swift */; };
 		DC8F111F1D0CD21700353DFB /* VoronoiDiagram+Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8F111E1D0CD21700353DFB /* VoronoiDiagram+Factory.swift */; };
@@ -73,6 +74,7 @@
 		DC11AF731CFFCC72001439BA /* VoronoiSiteEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoronoiSiteEvent.swift; sourceTree = "<group>"; };
 		DC11AF791CFFCC7C001439BA /* VoronoiCircleEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoronoiCircleEvent.swift; sourceTree = "<group>"; };
 		DC11AF7F1CFFCF97001439BA /* Circle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Circle.swift; sourceTree = "<group>"; };
+		DC2332211D204AC90013C3A9 /* VoronoiDiagramEdgeValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoronoiDiagramEdgeValidator.swift; sourceTree = "<group>"; };
 		DC8F110B1D0CB33800353DFB /* VoronoiLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoronoiLine.swift; sourceTree = "<group>"; };
 		DC8F11181D0CD19B00353DFB /* GLSVoronoiSprite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GLSVoronoiSprite.swift; sourceTree = "<group>"; };
 		DC8F111E1D0CD21700353DFB /* VoronoiDiagram+Factory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VoronoiDiagram+Factory.swift"; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 				DCEDF54A1D0B98F8000E7D05 /* VoronoiCornerConnector.swift */,
 				DC11AF371CFFAC3D001439BA /* VoronoiDiagram.swift */,
 				DC8F111E1D0CD21700353DFB /* VoronoiDiagram+Factory.swift */,
+				DC2332211D204AC90013C3A9 /* VoronoiDiagramEdgeValidator.swift */,
 				DC11AF381CFFAC3D001439BA /* VoronoiEdge.swift */,
 				DC11AF391CFFAC3D001439BA /* VoronoiEvent.swift */,
 				DC8F110B1D0CB33800353DFB /* VoronoiLine.swift */,
@@ -262,6 +265,7 @@
 				DC11AF3B1CFFAC3D001439BA /* ExposedBinarySearchTree.swift in Sources */,
 				DC11AF3C1CFFAC3D001439BA /* SwiftPriorityQueue.swift in Sources */,
 				DC11AF741CFFCC72001439BA /* VoronoiSiteEvent.swift in Sources */,
+				DC2332221D204AC90013C3A9 /* VoronoiDiagramEdgeValidator.swift in Sources */,
 				DC11AF801CFFCF97001439BA /* Circle.swift in Sources */,
 				DC8F11191D0CD19B00353DFB /* GLSVoronoiSprite.swift in Sources */,
 				DC11AF7A1CFFCC7C001439BA /* VoronoiCircleEvent.swift in Sources */,

--- a/Voronoi/VoronoiCell.swift
+++ b/Voronoi/VoronoiCell.swift
@@ -14,6 +14,18 @@ import OmniSwift
  */
 public class VoronoiCell {
     
+    private enum TraversalResult {
+        ///This is for when the start vertices need
+        ///to be combined with the end vertices
+        case DeadEnd
+        ///This is for when the vertices have
+        ///already formed a loop.
+        case CompleteLoop
+        ///This is for when the vertices only
+        ///need the corners to be added.
+        case IncompleteLoop
+    }
+    
     ///The original voronoi point.
     public let voronoiPoint:CGPoint
     ///The boundaries of the VoronoiDiagram.
@@ -53,16 +65,17 @@ public class VoronoiCell {
         
         let (complete, startVertices) = self.seekToEndOfEdges(start, nextEdge: (start.startNeighbor, start.startPoint))
         //Inner cell, we already have a loop.
-        if complete || self.verticesAreComplete(startVertices) {
+        if complete == .CompleteLoop || self.verticesAreComplete(startVertices) {
             return startVertices
         }
         
         var verts:[CGPoint] = startVertices.reverse()
-        if !self.verticesAreOnEdges(startVertices) {
+//        var verts:[CGPoint] = []
+        if !self.verticesAreOnEdges(startVertices) && complete == .DeadEnd {
             //If the start vertices already connect edges, we don't want
             //to calculate the end vertices because that introduces duplicates
             //that are not necessarily adjacent, so they won't be caught by removeDuplicates.
-            let (_, endVertices) = self.seekToEndOfEdges(start, nextEdge: (start.endNeighbor, start.endPoint))
+            let (complete, endVertices) = self.seekToEndOfEdges(start, nextEdge: (start.endNeighbor, start.endPoint))
             verts += endVertices
         }
         verts = self.removeDuplicates(verts)
@@ -132,6 +145,7 @@ public class VoronoiCell {
         }
         return filteredVertices
     }
+    
     /**
      Iterates through a linked list of VoronoiCellEdges, adding each vertex.
      - parameters prev: The VoronoiCellEdge to start iterating at.
@@ -139,7 +153,10 @@ public class VoronoiCell {
      - returns: A tuple. The first element is true if the vertex loop has already been completed (whether the last
      point connects to the first point). The second element is the vertices of this side of the loop, in order.
      */
-    private func seekToEndOfEdges(prev:VoronoiCellEdge, nextEdge:(edge:VoronoiCellEdge?, vertex:CGPoint)) -> (complete:Bool, points:[CGPoint]) {
+    private func seekToEndOfEdges(prev:VoronoiCellEdge, nextEdge:(edge:VoronoiCellEdge?, vertex:CGPoint)) -> (complete:TraversalResult, points:[CGPoint]) {
+        
+        var edgeValidator = VoronoiDiagramEdgeValidator(boundaries: self.boundaries)
+        
         let frame = CGRect(size: self.boundaries)
         let first       = prev
         var vertices:[CGPoint] = []
@@ -151,27 +168,50 @@ public class VoronoiCell {
         if frame.contains(nextEdge.vertex) && !vertices.contains({ $0 ~= nextEdge.vertex }) {
             vertices.append(nextEdge.vertex)
         }
+        //We're not actually going to restrict added points here,
+        //we just need to initialize the edge validator with the
+        //points and edges that already exist.
+        for v in vertices {
+            edgeValidator.validatePoint(v)
+        }
 
+        
+        func hasEnteredDiagram() -> Bool {
+            return vertices.count > 0
+        }
+        
         while let after = next {
             let successor = after.getNextFrom(previous)
             next = successor.edge
             previous = after
             
             if after === first {
-                return (true, vertices)
+                return (edgeValidator.validatePoint(successor.vertex) ? .IncompleteLoop : .CompleteLoop, vertices)
             }
             
             //The reason we calculate an array of intersections is that
             //it's possible (usually for voronoi points near the corners of the diagram)
             //to have an edge that both starts and ends outside the diagram, in which
             //case there are 2 intersections with the boundaries we need to account for.
+            //The last else-if statement is the only case in which there will by multiple
+            //elements in the array, though. The first two are guaranteed to have < 2.
             if !frame.contains(after.startPoint) && frame.contains(after.endPoint) {
                 for bv in after.intersectionWith(self.boundaries) {
-                    vertices.append(bv)
+                    if edgeValidator.validatePoint(bv) {
+                        vertices.append(bv)
+                    } else {
+//                        vertices.append(bv)
+                        return (.DeadEnd, vertices)
+                    }
                 }
             } else if frame.contains(after.startPoint) && !frame.contains(after.endPoint) {
                 for bv in after.intersectionWith(self.boundaries) {
-                    vertices.append(bv)
+                    if edgeValidator.validatePoint(bv) {
+                        vertices.append(bv)
+                    } else {
+//                        vertices.append(bv)
+                        return (.DeadEnd, vertices)
+                    }
                 }
             } else if !frame.contains(after.startPoint) && !frame.contains(after.endPoint) {
                 let intersections = after.intersectionWith(self.boundaries)
@@ -180,20 +220,38 @@ public class VoronoiCell {
                 }
             }
             
+            /*if let last = last where last ~= successor.vertex {
+                //We don't technically consider this case to be finished,
+                //because it only occurs when two arrays combined form
+                //a complete loop. However, this is only called in one
+                //instance, and it doesn't even check the first field
+                //in the tuple, so it doesn't matter what we return.
+                return (false, vertices)
+            }*/
+            
+            if !edgeValidator.validatePoint(successor.vertex) {
+                return (.DeadEnd, vertices)
+            }
             if frame.contains(successor.vertex) {
                 vertices.append(successor.vertex)
             } else if frame.contains(prevVertex) {
+//                vertices.append(successor.vertex)
                 //If the frame contains the last vertex but not the next vertex,
                 //it means we were in the frame but no longer are, so we want to return.
                 //If both vertices are outside the frame, we want to keep going, because
                 //it's valid for an entire edge to lie outside the frame; we just won't
                 //add the out-of-bounds vertices.
-                return (false, vertices)
+                
+                //Reset the edge validator, that way, if we exit the diagram
+                //and enter it on the same boundary (which is valid), the
+                //validator doesn't consider that edge in case the cell's
+                //edges exit and enter on another boundary.
+//                return (false, vertices)
             }
             
             prevVertex = successor.vertex
         }
-        return (false, vertices)
+        return (.DeadEnd, vertices)
     }
 
 }

--- a/Voronoi/VoronoiDiagramEdgeValidator.swift
+++ b/Voronoi/VoronoiDiagramEdgeValidator.swift
@@ -42,12 +42,14 @@ internal struct VoronoiDiagramEdgeValidator {
     }
     
     internal let boundaries:CGSize
+    ///The boundaries of the diagram
+    ///crossed by the edges of the cell.
     private var touchedEdges = Edge.None
+    ///The last point checked for validation.
     private var previousPoint:CGPoint? = nil
     
     internal init(boundaries:CGSize) {
         self.boundaries = boundaries
-        print("**********")
     }
     
     /**
@@ -64,15 +66,24 @@ internal struct VoronoiDiagramEdgeValidator {
         return (self.touchedEdges.rawValue & edge.rawValue) != 0
     }
     
+    /**
+     Checks if a point is contained in the voronoi diagram
+     (CGRect.contains does not return true if the point lies
+     exactly on the edge of the rectangle, which is undesired behaviour).
+     - parameter point: The point to check.
+     - returns: true if the point lies inside the boundaries, false otherwise.
+     */
     private func containsPoint(point:CGPoint) -> Bool {
         return 0.0 <= point.x && point.x <= self.boundaries.width
             && 0.0 <= point.y && point.y <= self.boundaries.height
     }
     
-    private func pointIsOnEdge(point:CGPoint) -> Bool {
-        return point.x ~= 0.0 || point.x ~= self.boundaries.width || point.y ~= 0.0 || point.y ~= self.boundaries.height
-    }
-    
+    /**
+     Determines if the previous point lied in the boundaries
+     of the diagram.
+     - returns: true if the previous point lied in the boundaries
+     or if there was no previous point, false otherwise.
+     */
     private func previousPointLiedInBoundaries() -> Bool {
         guard let previousPoint = self.previousPoint else {
             return true
@@ -99,7 +110,6 @@ internal struct VoronoiDiagramEdgeValidator {
         //We have to account for the case in which
         //a point lies exactly on a corner (and thus
         //lies on two edges)
-        let previousTouchedEdges = self.touchedEdges
         var shouldAdd = true
         if point.x ~= 0.0 {
             if !self.contains(.Left) && self.contains(.AllButLeft) {
@@ -125,18 +135,11 @@ internal struct VoronoiDiagramEdgeValidator {
             self.touchedEdges.unionInPlace(.Top)
         }
         
-        let liedInBoundaries = self.previousPointLiedInBoundaries()
-        /*if self.boundariesRect.contains(point) && !liedInBoundaries {
-            //If the edges have not changed but the point is valid,
-            //that means we're adding a point on the same edge, so we
-            //should reset so we don't interfere with exits on other boundaries.
-            self.reset()
-        }*/
         self.previousPoint = point
-        print("Point: \(point.clampDecimals(1))")
-        return shouldAdd// || liedInBoundaries
+        return shouldAdd
     }
     
+    ///Removes all touched edges.
     internal mutating func reset() {
         self.touchedEdges = Edge.None
     }

--- a/Voronoi/VoronoiDiagramEdgeValidator.swift
+++ b/Voronoi/VoronoiDiagramEdgeValidator.swift
@@ -1,0 +1,144 @@
+//
+//  VoronoiDiagramEdgeValidator.swift
+//  Voronoi
+//
+//  Created by Cooper Knaak on 6/26/16.
+//  Copyright © 2016 Cooper Knaak. All rights reserved.
+//
+
+import UIKit
+import OmniSwift
+
+/**
+ Handles cases where portions of edges of a VoronoiCell lie
+ outside the VoronoiDiagram. In some cases, the VoronoiCell
+ should stop traversing the edges, but in some cases, it
+ shoudl continue.
+ */
+internal struct VoronoiDiagramEdgeValidator {
+    
+    internal struct Edge: OptionSetType {
+        
+        internal let rawValue:Int
+        
+        internal init(rawValue:Int) {
+            self.rawValue = rawValue
+        }
+        
+        static let None             = Edge(rawValue: 0b0000)
+        static let All              = Edge(rawValue: 0b1111)
+
+        static let Right            = Edge(rawValue: 0b0001)
+        static let AllButRight      = Edge(rawValue: 0b1110)
+        
+        static let Top              = Edge(rawValue: 0b0010)
+        static let AllButTop        = Edge(rawValue: 0b1101)
+        
+        static let Left             = Edge(rawValue: 0b0100)
+        static let AllButLeft       = Edge(rawValue: 0b1011)
+        
+        static let Bottom           = Edge(rawValue: 0b1000)
+        static let AllButBottom     = Edge(rawValue: 0b0111)
+    }
+    
+    internal let boundaries:CGSize
+    private var touchedEdges = Edge.None
+    private var previousPoint:CGPoint? = nil
+    
+    internal init(boundaries:CGSize) {
+        self.boundaries = boundaries
+        print("**********")
+    }
+    
+    /**
+     Determines if the set of touched edges
+     intersects the given edge (normally I would
+     call the .contains method on OptionSetType,
+     but I want to consider any intersection valid,
+     not a total intersection. That is, Edge.All.contains(Edge.right)
+     is false, because the intersection of Edge.All and
+     Edge.right is not equal to Edge.All, but I want to
+     consider that true.
+     */
+    private func contains(edge:Edge) -> Bool {
+        return (self.touchedEdges.rawValue & edge.rawValue) != 0
+    }
+    
+    private func containsPoint(point:CGPoint) -> Bool {
+        return 0.0 <= point.x && point.x <= self.boundaries.width
+            && 0.0 <= point.y && point.y <= self.boundaries.height
+    }
+    
+    private func pointIsOnEdge(point:CGPoint) -> Bool {
+        return point.x ~= 0.0 || point.x ~= self.boundaries.width || point.y ~= 0.0 || point.y ~= self.boundaries.height
+    }
+    
+    private func previousPointLiedInBoundaries() -> Bool {
+        guard let previousPoint = self.previousPoint else {
+            return true
+        }
+        return self.containsPoint(previousPoint)
+    }
+
+    /**
+     Determines if a points should be added to the
+     traversed vertices. If the traversed vertices
+     have already crossed the boundaries of the VoronoiDiagram,
+     and they are crossing again, we have two cases. If the
+     edges are crossing the same boundary as before, we want
+     to continue traversing. If the edges are crossing a new
+     boundary, that means we will have skipped a corner, so
+     we do not add the vertex.
+     */
+    internal mutating func validatePoint(point:CGPoint) -> Bool {
+        
+        if self.previousPointLiedInBoundaries() && self.containsPoint(point) {
+            self.reset()
+        }
+        
+        //We have to account for the case in which
+        //a point lies exactly on a corner (and thus
+        //lies on two edges)
+        let previousTouchedEdges = self.touchedEdges
+        var shouldAdd = true
+        if point.x ~= 0.0 {
+            if !self.contains(.Left) && self.contains(.AllButLeft) {
+                shouldAdd = false
+            }
+            self.touchedEdges.unionInPlace(.Left)
+        } else if point.x ~= self.boundaries.width {
+            if !self.contains(.Right) && self.contains(.AllButRight) {
+                shouldAdd = false
+            }
+            self.touchedEdges.unionInPlace(.Right)
+        }
+        
+        if point.y ~= 0.0 {
+            if !self.contains(.Bottom) && self.contains(.AllButBottom) {
+                shouldAdd = false
+            }
+            self.touchedEdges.unionInPlace(.Bottom)
+        } else if point.y ~= self.boundaries.height {
+            if !self.contains(.Top) && self.contains(.AllButTop) {
+                shouldAdd = false
+            }
+            self.touchedEdges.unionInPlace(.Top)
+        }
+        
+        let liedInBoundaries = self.previousPointLiedInBoundaries()
+        /*if self.boundariesRect.contains(point) && !liedInBoundaries {
+            //If the edges have not changed but the point is valid,
+            //that means we're adding a point on the same edge, so we
+            //should reset so we don't interfere with exits on other boundaries.
+            self.reset()
+        }*/
+        self.previousPoint = point
+        print("Point: \(point.clampDecimals(1))")
+        return shouldAdd// || liedInBoundaries
+    }
+    
+    internal mutating func reset() {
+        self.touchedEdges = Edge.None
+    }
+    
+}


### PR DESCRIPTION
The algorithm in VoronoiCell.seekToEndOfEdges now always works if the cell's edges exited the boundaries of the diagram and then reentered the boundaries later.
closes #2 
