### PR TITLE
Neighbors unique

### DIFF
--- a/Sources/Voronoi/VoronoiCell.swift
+++ b/Sources/Voronoi/VoronoiCell.swift
@@ -29,7 +29,7 @@ open class VoronoiCell {
     internal var cellEdges:[VoronoiEdge] = []
     ///The neighboring cells adjacent to this cell.
     ///They must be weak references because otherwise, we have retain cycles.
-    internal var weakNeighbors:[WeakReference<VoronoiCell>] = []
+    internal var weakNeighbors:Set<WeakReference<VoronoiCell>> = []
     open var neighbors:[VoronoiCell] { return self.weakNeighbors.compactMap() { $0.object } }
     
     ///The set of the voronoi diagram's boundaries that this
@@ -155,7 +155,7 @@ open class VoronoiCell {
      - parameter neighbor: The cell adjacent to this cell to mark as a neighbor.
      */
     internal func add(neighbor:VoronoiCell) {
-        self.weakNeighbors.append(WeakReference(object: neighbor))
+        self.weakNeighbors.insert(WeakReference(object: neighbor))
     }
     
 }

--- a/Sources/Voronoi/VoronoiDiagram.swift
+++ b/Sources/Voronoi/VoronoiDiagram.swift
@@ -15,7 +15,7 @@ import CoronaMath
  Given a set of voronoi points and the boundaries of the diagram, uses Fortune's
  algorithm to calculate the edges between the voronoi points.
  */
-open class VoronoiDiagram: NSObject {
+open class VoronoiDiagram {
     
     ///An array of voronoi points.
     public let points:[Point]
@@ -51,8 +51,6 @@ open class VoronoiDiagram: NSObject {
         self.points = points
         self.size   = size
         self.cells  = points.map() { VoronoiCell(point: $0, boundaries: size) }
-        
-        super.init()
         
         for cell in self.cells {
             self.events.push(VoronoiSiteEvent(cell: cell))

--- a/Sources/Voronoi/WeakReference.swift
+++ b/Sources/Voronoi/WeakReference.swift
@@ -9,7 +9,8 @@ import Foundation
 
 ///A wrapper for a class object that maintains a weak reference to the object.
 ///For example, useful for storing weak references in an array.
-public class WeakReference<T: AnyObject> {
+public class WeakReference<T: AnyObject>: Hashable {
+
 
     ///The object to be wrapped.
     public private(set) weak var object:T? = nil
@@ -20,4 +21,20 @@ public class WeakReference<T: AnyObject> {
         self.object = object
     }
 
+    public func hash(into hasher: inout Hasher) {
+        if let obj = object {
+            hasher.combine(Unmanaged.passUnretained(obj).toOpaque())
+        }
+    }
+
+}
+
+public func ==<T>(lhs: WeakReference<T>, rhs: WeakReference<T>) -> Bool where T: AnyObject {
+    if lhs.object == nil && rhs.object == nil {
+        return true
+    }
+    guard let leftObject = lhs.object, let rightObject = rhs.object else {
+        return false
+    }
+    return Unmanaged.passUnretained(leftObject).toOpaque() == Unmanaged.passUnretained(rightObject).toOpaque()
 }


### PR DESCRIPTION
Fixes bug where `VoronoiCell.weakNeighbors` would contain multiple references to the same cell. This occurred because a single line could be represented by multiple edges with the same cells, adding a neighbor for each (non-distinct) edge.