### PR TITLE
Fixed bug where the wrong parabola was checked for a circle event aft…

### DIFF
--- a/Sources/Voronoi/ExposedBinarySearchTree.swift
+++ b/Sources/Voronoi/ExposedBinarySearchTree.swift
@@ -115,6 +115,7 @@ extension ExposedBinarySearchTreeProtocol {
         self.left?.iterateChildren(handler)
         self.right?.iterateChildren(handler)
     }
+
 }
 
 /**
@@ -240,6 +241,12 @@ public struct ExposedBinarySearchTree<T: ExposedBinarySearchTreeProtocol>: Custo
         if let right = node.right {
             self.iterateNode(right, requireLeaf: requireLeaf, handler: handler)
         }
+    }
+
+    public func getLeaves() -> [T] {
+        var leaves:[T] = []
+        self.iterateLeaves() { leaves.append($0) }
+        return leaves
     }
     
     fileprivate static func toString(_ val:T, depth:Int) -> String {

--- a/Sources/Voronoi/VoronoiCell.swift
+++ b/Sources/Voronoi/VoronoiCell.swift
@@ -96,20 +96,14 @@ open class VoronoiCell {
         for cellEdge in self.cellEdges {
             let line = VoronoiLine(start: cellEdge.startPoint, end: cellEdge.endPoint, voronoi: self.voronoiPoint)
             corners = corners.filter() { line.pointLiesAbove($0) == line.voronoiPointLiesAbove }
-            
+
             let intersections = cellEdge.intersectionWith(self.boundaries)
             vertices += intersections
-            for intersection in intersections {
-                self.insertBoundaryEdge(for: intersection)
-            }
-
             if frame.contains(point: cellEdge.startPoint) {
                 vertices.append(cellEdge.startPoint)
-                self.insertBoundaryEdge(for: cellEdge.startPoint)
             }
             if frame.contains(point: cellEdge.endPoint) {
                 vertices.append(cellEdge.endPoint)
-                self.insertBoundaryEdge(for: cellEdge.endPoint)
             }
         }
         vertices += corners
@@ -126,6 +120,7 @@ open class VoronoiCell {
             vertices = vertices.sorted() { center.angle(to: $0) < center.angle(to: $1) }
         }
         vertices = self.removeDuplicates(vertices)
+        self._boundaryEdges = self.calculateBoundaryEdges(vertices: vertices)
         return vertices
     }
     
@@ -148,6 +143,30 @@ open class VoronoiCell {
             }
         }
         return filteredVertices
+    }
+
+    /**
+     Determines which edges of the voronoi diagram this cell touches.
+     - parameter vertices: The vertices of this cell.
+     - returns: A set of directions corresponding to which edges of the boundaries this cell touches.
+     */
+    fileprivate func calculateBoundaryEdges(vertices:[Point]) -> Set<Direction2D> {
+        var edges:Set<Direction2D> = []
+        for vertex in vertices {
+            if vertex.x ~= 0.0 {
+                edges.insert(.Left)
+            }
+            if vertex.x ~= self.boundaries.width {
+                edges.insert(.Right)
+            }
+            if vertex.y ~= 0.0 {
+                edges.insert(.Down)
+            }
+            if vertex.y ~= self.boundaries.height {
+                edges.insert(.Up)
+            }
+        }
+        return edges
     }
 
     /**

--- a/Sources/Voronoi/VoronoiDiagram.swift
+++ b/Sources/Voronoi/VoronoiDiagram.swift
@@ -227,7 +227,7 @@ open class VoronoiDiagram {
             rightEdge.leftParabola  = newParab  
             rightEdge.rightParabola = rParab
             
-            self.checkCircleEventForParabola(lParab)
+            self.checkCircleEventForParabola(leftParab)
             self.checkCircleEventForParabola(rParab)
             return
         } else if let rParab = parab.getParabolaToRight() , VoronoiParabola.parabolaCollisions(parab.focus, focus2: rParab.focus, directrix: self.sweepLine).contains(where: { $0.x ~= point.x }) {
@@ -277,7 +277,6 @@ open class VoronoiDiagram {
             rightEdge.rightParabola = rightParab
             
             self.checkCircleEventForParabola(lParab)
-            self.checkCircleEventForParabola(newParab)
             self.checkCircleEventForParabola(rightParab)
             return
         }
@@ -392,11 +391,9 @@ open class VoronoiDiagram {
         guard let circle        = VoronoiDiagram.calculateCircle([leftChild.focus, parabola.focus, rightChild.focus]) else {
             return
         }
-        
         guard circle.center.y + circle.radius >= self.sweepLine else {
             return
         }
-        
         guard let leftEdge = leftChild.rightEdge, let rightEdge = rightChild.leftEdge, let _ = self.calculateCollisionOfEdges(leftEdge, right: rightEdge) else {
             return
         }
@@ -534,7 +531,6 @@ open class VoronoiDiagram {
         let cNeg        = points[1].x - points[0].x
         let x           = (aSquared * a + bSquared * b + cSquared * c) / d
         let y           = (aSquared * aNeg + bSquared * bNeg + cSquared * cNeg) / d
-        
         let center = Point(x: x, y: y)
         return Circle(center: center, radius: center.distanceFrom(vector: points[0]))
     }

--- a/Sources/Voronoi/VoronoiParabola.swift
+++ b/Sources/Voronoi/VoronoiParabola.swift
@@ -14,7 +14,7 @@ import CoronaMath
  Stores the edges connected to this parabola and the cell associated with its focus.
  Also acts as a node for a binary search tree.
  */
-internal final class VoronoiParabola: ExposedBinarySearchTreeProtocol {
+internal final class VoronoiParabola: ExposedBinarySearchTreeProtocol, CustomStringConvertible {
     
     ///The cell associated with this parabola's focus.
     internal let cell:VoronoiCell
@@ -59,6 +59,10 @@ internal final class VoronoiParabola: ExposedBinarySearchTreeProtocol {
         self.cell       = cell
         self.focus      = cell.voronoiPoint
         self.directix   = cell.voronoiPoint.y
+    }
+
+    internal var description: String {
+        return "\(self.cell.voronoiPoint)"
     }
     
     /**


### PR DESCRIPTION
Fixed bug where the wrong parabola was checked for a circle event after adding a parabola whose focus is aligned vertically with another voronoi point.

Corrected method for determining which edges of the boundaries of a voronoi diagram that a voronoi point touches.